### PR TITLE
fixing frontend API URL

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,19 +4,17 @@ COPY package.json package-lock.json ./
 RUN npm install
 
 FROM node:18-alpine AS build
-
-ARG REACT_APP_API_URL
-ENV REACT_APP_API_URL=$REACT_APP_API_URL
-
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-
 RUN npm run build
 
 FROM nginx:stable-alpine
 RUN rm -rf /usr/share/nginx/html/*
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/entrypoint.sh
+++ b/frontend/src/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+echo "Starting runtime substitution for REACT_APP_API_URL..."
+
+if [ -z "$REACT_APP_API_URL" ]; then
+  echo "Error: REACT_APP_API_URL is not set. Exiting."
+  exit 1
+fi
+
+find /usr/share/nginx/html -type f -name "*.js" -exec sed -i "s|__REACT_APP_API_URL__|$REACT_APP_API_URL|g" {} \;
+
+echo "Substitution complete. Starting Nginx..."
+exec "$@"

--- a/frontend/src/services/api.jsx
+++ b/frontend/src/services/api.jsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-export const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost/api/';
+export const API_BASE_URL = "__REACT_APP_API_URL__";
 
 
 export const obtainToken = (username, password) => {

--- a/stack.yml
+++ b/stack.yml
@@ -81,10 +81,6 @@ services:
       replicas: 2
       restart_policy:
         condition: on-failure
-    build:
-      context: ./frontend
-      args:
-        REACT_APP_API_URL: "https://is-schedule.updspace.com/api/"
 
   db:
     image: postgres:15


### PR DESCRIPTION
This pull request introduces several changes to the frontend build and deployment process to support runtime environment variable substitution for `REACT_APP_API_URL`. The most important changes include modifications to the Dockerfile, the addition of an entrypoint script, updates to the API service configuration, and adjustments to the Docker Compose stack file.

Improvements to build and deployment process:

* [`frontend/Dockerfile`](diffhunk://#diff-ea60ef29f6f537c1c83468c00b60de28f86e06edfe4a3d91274723c6f298fdb8L7-R19): Removed the `ARG` and `ENV` instructions for `REACT_APP_API_URL` and added a new entrypoint script to handle runtime substitution.
* [`frontend/src/entrypoint.sh`](diffhunk://#diff-fc221160683a65b8f4ec14f42cc5fb60e2313604d2a21c72cadc3dccdee5d1c4R1-R14): Added a new shell script to perform runtime substitution of `REACT_APP_API_URL` in the built JavaScript files before starting Nginx.

Codebase simplification:

* [`frontend/src/services/api.jsx`](diffhunk://#diff-ec456a49b691ad1a6c44f188cbc4cc1051c2d68dab1ea5d1056edba8ab0a5864L3-R3): Updated the `API_BASE_URL` to use a placeholder string `__REACT_APP_API_URL__` for runtime substitution.

Configuration adjustments:

* [`stack.yml`](diffhunk://#diff-85060223500160bc2e4c8246e65790c0b04e1fd64a49d8f2cac78a89e80f46c1L84-L87): Removed the build context and `REACT_APP_API_URL` argument under the `services:` section for the frontend service.