### PR TITLE
Refactoring: fixing health check

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -30,7 +30,7 @@ services:
       - "traefik.http.routers.backend.tls=true"
       - "traefik.http.services.backend.loadbalancer.server.port=8000"
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f http://localhost:8000/health/ || exit 1" ]
+      test: [ "CMD-SHELL", "python -c \"import urllib.request; assert urllib.request.urlopen('http://localhost:8000/health/').getcode() == 200\" || exit 1" ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
This pull request includes a change to the health check command in the `stack.yml` file. The change updates the health check to use a Python script instead of a curl command.

* [`stack.yml`](diffhunk://#diff-85060223500160bc2e4c8246e65790c0b04e1fd64a49d8f2cac78a89e80f46c1L33-R33): Updated the health check command to use a Python script for verifying the health endpoint.